### PR TITLE
Fixed pagination for long result sets.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -83,10 +83,10 @@ class Client {
                     data = yield request.getQueryResults(queryId, nowConfig)
                     let previousToken
                     while (data.NextToken && data.NextToken !== previousToken) {
+                        previousToken = data.NextToken
                         let dataTmp = yield request.getQueryResults(queryId, nowConfig, data.NextToken)
                         data.NextToken = dataTmp.NextToken || null
                         data.ResultSet.Rows = data.ResultSet.Rows.concat(dataTmp.ResultSet.Rows)
-                        previousToken = data.NextToken
                     }
 
                     let format = options.format || nowConfig.format


### PR DESCRIPTION
This PR fixes problem of setting the same value to `previousToken` and `data.NextToken` which breaks `while` loop after first iteration even if result set has more pages.