### PR TITLE
Added optional bucketMetadataUri for csv results

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -10,7 +10,7 @@ class Request {
             let params = {
                 QueryString: query,
                 ResultConfiguration: {
-                    OutputLocation: config.bucketUri,
+                    OutputLocation: config.bucketMetadataUri || config.bucketUri
                 },
             }
             let loopFunc = () => {


### PR DESCRIPTION
I didn't want to clutter my s3 source bucket with the csv and metadata csv files because it messes with the table mapping, so this lets you specify an optional bucket where these metadata files get put.