### PR TITLE
Fix bug when pollingInterval or queryTimeout are empty in Config

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -110,8 +110,14 @@ function checkConfig(config_) {
     if (!config_.bucketUri) {
         throw new Error('buket uri required')
     }
-    config_.pollingInterval = Math.max(config_.pollingInterval, 0)
-    config_.queryTimeout = Math.max(config_.queryTimeout, 0)
+
+    if(!config_.pollingInterval || config_.pollingInterval < 0) {
+        config_.pollingInterval = 0;
+    }
+
+    if(!config_.queryTimeout || config_.queryTimeout < 0) {
+        config_.queryTimeout = 0;
+    }
 }
 
 function extractData(data, format) {

--- a/test/client.js
+++ b/test/client.js
@@ -311,12 +311,20 @@ describe('Array', function () {
             assert.throws(() => { let client = Client.create(mockReqest, newConfig) }, Error, 'buket uri required')
         })
 
-        it('should return valid pollingInterval error when pollingInterval is empty', function () {
+        it('should return valid pollingInterval when is empty', function () {
             let mockReqest = getMockRequest()
             let newConfig = Object.assign({}, config)
             delete newConfig.pollingInterval
             let client = Client.create(mockReqest, newConfig)
             assert.equal(client.config.pollingInterval, 0)
+        })
+
+        it('should return valid queryTimeout when is empty', function () {
+            let mockReqest = getMockRequest()
+            let newConfig = Object.assign({}, config)
+            delete newConfig.queryTimeout
+            let client = Client.create(mockReqest, newConfig)
+            assert.equal(client.config.queryTimeout, 0)
         })
     })
 })

--- a/test/client.js
+++ b/test/client.js
@@ -306,10 +306,17 @@ describe('Array', function () {
     describe('#setConfig()', function () {
         it('should return error when bucketUri is empty', function () {
             let mockReqest = getMockRequest()
-            let client = Client.create(mockReqest, config)
             let newConfig = Object.assign({}, config)
             newConfig.bucketUri = ""
-            assert.throws(() => { client.setConfig(newConfig) }, Error, 'buket uri required')
+            assert.throws(() => { let client = Client.create(mockReqest, newConfig) }, Error, 'buket uri required')
+        })
+
+        it('should return valid pollingInterval error when pollingInterval is empty', function () {
+            let mockReqest = getMockRequest()
+            let newConfig = Object.assign({}, config)
+            delete newConfig.pollingInterval
+            let client = Client.create(mockReqest, newConfig)
+            assert.equal(client.config.pollingInterval, 0)
         })
     })
 })


### PR DESCRIPTION
I was having strange performance issues when my code was deployed in an EC2 instance (was working ok in localhost). The queries where taking more than 40 seconds but in the history panel in Athena I was looking that the server respond normally in 1-2 seconds. 

After setting a config with `pollingInterval` the problem was gone. Printing the config after `checkConfig` I find that `pollingInterval` and `queryTimeout` took a NaN value. This because `Math.max(undefined, 0)` returns NaN.

```javascript
function checkConfig(config_) {
    if (!config_.bucketUri) {
        throw new Error('buket uri required')
    }
    config_.pollingInterval = Math.max(config_.pollingInterval, 0) --> NaN if undefined
    config_.queryTimeout = Math.max(config_.queryTimeout, 0) --> NaN if undefined
}
```

Probably the problem happen in production because EC2 instances have a very low latency with Athena servers, or something like this.

I add some tests and fix the test in `setConfig` (this function does not exists anymore).

